### PR TITLE
Add gomoku optimize edition

### DIFF
--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -38,7 +38,7 @@ public:
 
   bool is_valid(point p) const noexcept
   {
-    if (p.first >= width(), p.second >= height()) return false; // out range
+    if (p.first >= width() || p.second >= height()) return false; // out range
     return kind::space == access(std::move(p)); // if exist value, false.
   }
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -237,35 +237,17 @@ private:
     const point::first_type horizon_limit {board_.width() - finish_length_ + 1};
     const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
     using search_data = std::tuple<point, point, std::size_t>;
-    std::array<search_data, 4> search_datas {
-      search_data{{0, horizon_limit}, {0, board_.height()}, 1},
-      search_data{{0, board_.width()}, {0, vertical_limit}, board_.width()},
-      search_data{{0, horizon_limit}, {0, vertical_limit}, board_.width() + 1},
-      search_data{{finish_length_ - 1, board_.width()}, {0, vertical_limit}, board_.width() - 1}};
-    // horizon search
-    for (point::second_type y {0}; y < board_.height(); ++y)
-      for (point::first_type x {0}; x < horizon_limit; ++x) {
-        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, 1})};
-        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
-      }
-    // vertical search
-    for (point::first_type x {0}; x < board_.width(); ++x)
-      for (point::second_type y {0}; y < vertical_limit; ++y) {
-        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width()})};
-        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
-      }
-    // falling search
-    for (point::second_type y {0}; y < vertical_limit; ++y)
-      for (point::first_type x {0}; x < horizon_limit; ++x) {
-        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width() + 1})};
-        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
-      }
-    // soaring search
-    for (point::second_type y {0}; y < vertical_limit; ++y)
-      for (point::first_type x {finish_length_ - 1}; x < board_.width(); ++x) {
-        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width() - 1})};
-        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
-      }
+    const std::array<const search_data, 4> search_datas {
+      search_data{{0, horizon_limit}, {0, board_.height()}, 1}, // horizon
+      search_data{{0, board_.width()}, {0, vertical_limit}, board_.width()}, // vertical
+      search_data{{0, horizon_limit}, {0, vertical_limit}, board_.width() + 1}, // falling
+      search_data{{finish_length_ - 1, board_.width()}, {0, vertical_limit}, board_.width() - 1}}; // soaring
+    for (const auto& e : search_datas)
+      for (point::second_type y {std::get<1>(e).first}; y < std::get<1>(e).second; ++y)
+        for (point::first_type x {std::get<0>(e).first}; x < std::get<0>(e).second; ++x) {
+          auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, std::get<2>(e)})};
+          if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
+        }
     const auto& all_area {board_.get_data()};
     if (std::none_of(std::begin(all_area), std::end(all_area), [](auto e){return e == field::kind::space;})) return true;
     return false;

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -192,6 +192,7 @@ public:
       std::for_each(std::begin(line), std::end(line), [](auto e){std::cout << to_string(e);});
       std::cout << '\n';
     }
+    std::cout << std::endl;
   }
 
   void update()
@@ -218,13 +219,34 @@ private:
 
   bool is_game_finish() const noexcept
   {
-    const point::first_type horizon_limit {board_.width() - 5};
+    const auto active_kind {get_active_kind()};
+    const point::first_type horizon_limit {board_.width() - finish_length_};
     // horizon search
     for (point::second_type y {0}; y < board_.height(); ++y)
       for (point::first_type x {0}; x < horizon_limit; ++x) {
-        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), 5, 1})};
+        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, 1})};
+        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
       }
-    const point::second_type vertical_limit {board_.height() - 5};
+    // vertical search
+    const point::second_type vertical_limit {board_.height() - finish_length_};
+    for (point::first_type x {0}; x < board_.width(); ++x)
+      for (point::second_type y {0}; y < vertical_limit; ++y) {
+        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width()})};
+        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
+      }
+    // falling search
+    for (point::second_type y {0}; y < vertical_limit; ++y)
+      for (point::first_type x {0}; x < horizon_limit; ++x) {
+        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width() + 1})};
+        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
+      }
+    // soaring search
+    for (point::second_type y {finish_length_}; y < board_.height(); ++y)
+      for (point::first_type x {finish_length_}; x < board_.width(); ++x) {
+        auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width() - 1})};
+        if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
+      }
+    return false;
   }
 
   std::size_t             finish_length_;

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -236,12 +236,12 @@ private:
     const auto active_kind {get_active_kind()};
     const point::first_type horizon_limit {board_.width() - finish_length_ + 1};
     const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
-    using search_point = std::pair<point, point>;
-    std::array<search_point, 4> search_points {
-      search_point{{0, horizon_limit}, {0, board_.height()}},
-      search_point{{0, board_.width()}, {0, vertical_limit}},
-      search_point{{0, horizon_limit}, {0, vertical_limit}},
-      search_point{{finish_length_ - 1, board_.width()}, {0, vertical_limit}}};
+    using search_data = std::tuple<point, point, std::size_t>;
+    std::array<search_data, 4> search_datas {
+      search_data{{0, horizon_limit}, {0, board_.height()}, 1},
+      search_data{{0, board_.width()}, {0, vertical_limit}, board_.width()},
+      search_data{{0, horizon_limit}, {0, vertical_limit}, board_.width() + 1},
+      search_data{{finish_length_ - 1, board_.width()}, {0, vertical_limit}, board_.width() - 1}};
     // horizon search
     for (point::second_type y {0}; y < board_.height(); ++y)
       for (point::first_type x {0}; x < horizon_limit; ++x) {

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -235,6 +235,13 @@ private:
   {
     const auto active_kind {get_active_kind()};
     const point::first_type horizon_limit {board_.width() - finish_length_ + 1};
+    const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
+    using search_point = std::pair<point, point>;
+    std::array<search_point, 4> search_points {
+      search_point{point{0, horizon_limit}, point{0, board_.height()}},
+      search_point{point{0, board_.width()}, point{0, vertical_limit}},
+      search_point{point{0, horizon_limit}, point{0, vertical_limit}},
+      search_point{point{finish_length_ - 1, board_.width()}, point{0, vertical_limit}}};
     // horizon search
     for (point::second_type y {0}; y < board_.height(); ++y)
       for (point::first_type x {0}; x < horizon_limit; ++x) {
@@ -242,7 +249,6 @@ private:
         if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
       }
     // vertical search
-    const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
     for (point::first_type x {0}; x < board_.width(); ++x)
       for (point::second_type y {0}; y < vertical_limit; ++y) {
         auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width()})};

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -238,10 +238,10 @@ private:
     const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
     using search_point = std::pair<point, point>;
     std::array<search_point, 4> search_points {
-      search_point{point{0, horizon_limit}, point{0, board_.height()}},
-      search_point{point{0, board_.width()}, point{0, vertical_limit}},
-      search_point{point{0, horizon_limit}, point{0, vertical_limit}},
-      search_point{point{finish_length_ - 1, board_.width()}, point{0, vertical_limit}}};
+      search_point{{0, horizon_limit}, {0, board_.height()}},
+      search_point{{0, board_.width()}, {0, vertical_limit}},
+      search_point{{0, horizon_limit}, {0, vertical_limit}},
+      search_point{{finish_length_ - 1, board_.width()}, {0, vertical_limit}}};
     // horizon search
     for (point::second_type y {0}; y < board_.height(); ++y)
       for (point::first_type x {0}; x < horizon_limit; ++x) {

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -275,6 +275,24 @@ private:
 int main(int argc, char** argv)
 {
   std::ios_base::sync_with_stdio(false);
-  game_master master {std::make_unique<human_player>(), std::make_unique<computer_player>(), point{9, 9}};
+  std::unique_ptr<player> player1 {new human_player};
+  std::unique_ptr<player> player2 {new computer_player};
+  if (argc > 1) {
+    using namespace std::literals::string_literals;
+    if (argv[1] == "--auto"s)
+      player1.reset(new computer_player);
+    if (argv[1] == "--player"s)
+      player2.reset(new human_player);
+    if (argv[1] == "--com"s)
+      ; // not working
+  }
+  std::size_t board_size {9};
+  if (argc > 2)
+    board_size = std::stoul(argv[2]);
+  std::size_t finish_size {5};
+  if (argc > 3)
+    finish_size = std::stoul(argv[3]);
+
+  game_master master {std::move(player1), std::move(player2), point{board_size, board_size}, finish_size};
   master.run();
 }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -42,6 +42,11 @@ public:
     return kind::space == access(std::move(p)); // if exist value, false.
   }
 
+  bool is_valid(point::first_type x, point::second_type y) const noexcept
+  {
+    return is_valid({x, y});
+  }
+
   point::first_type width() const noexcept
   {
     return size_.first;
@@ -167,11 +172,11 @@ class game_master
 public:
   template<typename Player1, typename Player2>
   game_master(std::unique_ptr<Player1> player1, std::unique_ptr<Player2> player2, point size, std::size_t finish_length = 5)
-    : finish_length_ {finish_length},
-      player1_       {player1.release()},
+    : player1_       {player1.release()},
       player2_       {player2.release()},
       active_player_ {player1_.get()},
-      board_         {std::move(size)}
+      board_         {std::move(size)},
+      finish_length_ {board_.is_valid(finish_length - 1, finish_length - 1) ? finish_length : throw std::out_of_range{"game_master: cannot clear/ finish_length > board_size"}}
   {
   }
 
@@ -260,11 +265,11 @@ private:
     return false;
   }
 
-  std::size_t             finish_length_;
   std::unique_ptr<player> player1_;
   std::unique_ptr<player> player2_;
   player*                 active_player_;
   field                   board_;
+  std::size_t             finish_length_;
 };
 
 int main(int argc, char** argv)

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -64,6 +64,12 @@ public:
   }
 
   template<typename T>
+  data_type get_col(T x) const noexcept
+  {
+    return data_[std::slice(get_access_number(x, 0), height(), width())];
+  }
+
+  template<typename T>
   data_type get_row(T y) const noexcept
   {
     return data_[std::slice(get_access_number(0, y), width(), 1)];

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -279,12 +279,12 @@ int main(int argc, char** argv)
     if (argv[1] == "--com"s)
       ; // not working
   }
-  std::size_t board_size {9};
-  if (argc > 2)
-    board_size = std::stoul(argv[2]);
   std::size_t finish_size {5};
-  if (argc > 3)
+  if (argc > 2)
     finish_size = std::stoul(argv[3]);
+  std::size_t board_size {9};
+  if (argc > 3)
+    board_size = std::stoul(argv[2]);
 
   game_master master {std::move(player1), std::move(player2), point{board_size, board_size}, finish_size};
   master.run();

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <memory>
 #include <numeric>
+#include <stdexcept>
 #include <utility>
 #include <valarray>
 
@@ -29,11 +30,14 @@ public:
 
   void put(point p, kind k)
   {
+    if (!is_valid(p)) throw std::out_of_range {"field: fail access on put the stone"};
+    access(p) = k;
   }
 
   bool is_valid(point p) const noexcept
   {
-    return kind::space == data_[width() * p.second + p.first];
+    if (p.first >= width(), p.second >= height()) return false; // out range
+    return kind::space == access(p); // if exist value, false.
   }
 
   point::first_type width() const noexcept
@@ -47,8 +51,20 @@ public:
   }
 
 private:
-  point      size_;
-  value_type data_;
+  using data_type = std::valarray<kind>;
+
+  data_type::value_type& access(point p) noexcept
+  {
+    return data_[width() * p.second + p.first];
+  }
+
+  const data_type::value_type& access(point p) const noexcept
+  {
+    return data_[width() * p.second + p.first];
+  }
+
+  point     size_;
+  data_type data_;
 };
 
 class player

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 #include <valarray>
 
-//! The point class. But I implement it.
+//! The point class. But I don't implement it.
 using point = std::pair<std::size_t, std::size_t>;
 
 //! The game field class.

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -176,7 +176,6 @@ public:
       draw();
       update();
     }
-    draw();
     std::cout << is_first_player();
   }
 
@@ -241,8 +240,8 @@ private:
         if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
       }
     // soaring search
-    for (point::second_type y {finish_length_}; y < board_.height(); ++y)
-      for (point::first_type x {finish_length_}; x < board_.width(); ++x) {
+    for (point::second_type y {0}; y < vertical_limit; ++y)
+      for (point::first_type x {finish_length_ - 1}; x < board_.width(); ++x) {
         auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width() - 1})};
         if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
       }
@@ -259,6 +258,6 @@ private:
 int main(int argc, char** argv)
 {
   std::ios_base::sync_with_stdio(false);
-  game_master master {std::make_unique<computer_player>(), std::make_unique<computer_player>(), point{9, 9}};
+  game_master master {std::make_unique<human_player>(), std::make_unique<computer_player>(), point{9, 9}};
   master.run();
 }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -86,6 +86,11 @@ public:
     return data_;
   }
 
+  void init()
+  {
+    data_ = kind::space;
+  }
+
 private:
   data_type::value_type& access(point p) noexcept
   {
@@ -172,11 +177,22 @@ public:
 
   void run()
   {
-    while (!is_game_finish()) {
+    init();
+    while (true) { // when is_game_finish to break to end.
       draw();
       update();
+      if (is_game_finish())
+        break;
+      switch_player();
     }
-    std::cout << is_first_player();
+    draw();
+    std::cout << "winner " << (is_first_player() ? "player 1" : "player 2") << std::endl;
+  }
+
+  void init()
+  {
+    active_player_ = player1_.get();
+    board_.init();
   }
 
   void draw()
@@ -197,7 +213,6 @@ public:
   void update()
   {
     board_.put(active_player_->get_point(board_), get_active_kind());
-    switch_player();
   }
 
 private:

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -106,7 +106,7 @@ private:
   data_type data_;
 };
 
-static char to_string(field::kind k) noexcept
+char to_string(field::kind k) noexcept
 {
   return k == field::kind::space ? ' ' :
          k == field::kind::white ? 'O' :
@@ -189,6 +189,7 @@ public:
     std::cout << "winner " << (is_first_player() ? "player 1" : "player 2") << std::endl;
   }
 
+private:
   void init()
   {
     active_player_ = player1_.get();
@@ -207,7 +208,7 @@ public:
       std::for_each(std::begin(line), std::end(line), [](auto e){std::cout << to_string(e);});
       std::cout << '\n';
     }
-    std::cout << std::endl;
+    std::cout << "\nThe turn of player " << get_player_number() << '.' << std::endl;
   }
 
   void update()
@@ -215,7 +216,6 @@ public:
     board_.put(active_player_->get_point(board_), get_active_kind());
   }
 
-private:
   bool is_first_player() const noexcept
   {
     return player1_.get() == active_player_;
@@ -229,6 +229,11 @@ private:
   field::kind get_active_kind() const noexcept
   {
     return is_first_player() ? field::kind::black : field::kind::white;
+  }
+
+  std::size_t get_player_number() const noexcept
+  {
+    return is_first_player() ? 1 : 2;
   }
 
   bool is_game_finish() const noexcept

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -234,7 +234,7 @@ private:
   bool is_game_finish() const noexcept
   {
     const auto active_kind {get_active_kind()};
-    const point::first_type horizon_limit {board_.width() - finish_length_};
+    const point::first_type horizon_limit {board_.width() - finish_length_ + 1};
     // horizon search
     for (point::second_type y {0}; y < board_.height(); ++y)
       for (point::first_type x {0}; x < horizon_limit; ++x) {
@@ -242,7 +242,7 @@ private:
         if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
       }
     // vertical search
-    const point::second_type vertical_limit {board_.height() - finish_length_};
+    const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
     for (point::first_type x {0}; x < board_.width(); ++x)
       for (point::second_type y {0}; y < vertical_limit; ++y) {
         auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width()})};
@@ -260,6 +260,8 @@ private:
         auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, board_.width() - 1})};
         if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
       }
+    const auto& all_area {board_.get_data()};
+    if (std::none_of(std::begin(all_area), std::end(all_area), [](auto e){return e == field::kind::space;})) return true;
     return false;
   }
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -1,0 +1,161 @@
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <utility>
+#include <valarray>
+
+//! The point class. But I implement it.
+using point = std::pair<std::size_t, std::size_t>;
+
+//! The game field class.
+class field
+{
+public:
+  //! The kind of field state.
+  enum class kind
+  {
+    space,
+    white,
+    black
+  };
+
+  //! Create the field [size.second][size.first]
+  field(const point& size)
+    : size_ {size},
+      data_ {size.second * size.first}
+  {
+  }
+
+  void put(point p, kind k)
+  {
+  }
+
+  bool is_valid(point p) const noexcept
+  {
+    return kind::space == data_[width() * p.second + p.first];
+  }
+
+  point::first_type width() const noexcept
+  {
+    return size_.first;
+  }
+
+  point::second_type height() const noexcept
+  {
+    return size_.second;
+  }
+
+private:
+  point      size_;
+  value_type data_;
+};
+
+class player
+{
+public:
+  virtual ~player() = default;
+  virtual point get_point(const field&) = 0;
+};
+
+class human_player
+  : public player
+{
+public:
+  point get_point(const field& valid_area) override
+  {
+    point p;
+    do {
+      std::cout << "where set to? [x y]\n > " << std::flush;
+      std::cin >> p.first >> p.second;
+      std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    } while (!valid_area.is_valid(p) && std::cout << "wrong input." << std::endl); // out range
+    return p;
+  }
+};
+
+class computer_player
+  : public player
+{
+public:
+  computer_player()
+    : rand_ {std::random_device{}()}
+  {
+  }
+
+  point get_point(const field& valid_area) override
+  {
+    std::uniform_int_distribution<point::first_type> dist_x {0, valid_area.width() - 1};
+    std::uniform_int_distribution<point::second_type> dist_y {0, valid_area.height() - 1};
+    return {dist_x(rand_), dist_y(rand_)};
+  }
+
+private:
+  std::default_random_engine rand_;
+};
+
+class game_master
+{
+public:
+  template<typename Player1, typename Player2>
+  game_master(std::unique_ptr<Player1> player1, std::unique_ptr<Player2> player2, const point& size)
+    : player1_       {player1.release()},
+      player2_       {player2.release()},
+      active_player_ {player1_.get()},
+      board_         {size}
+  {
+  }
+
+  void run()
+  {
+    while (!is_game_finish()) {
+      draw();
+      update();
+    }
+    draw();
+    std::cout << is_first_player();
+  }
+
+  void draw()
+  {
+  }
+
+  void update()
+  {
+    board_.put(active_player_->get_point(board_), get_active_kind());
+    switch_player();
+  }
+
+private:
+  bool is_first_player() const noexcept
+  {
+    return player1_.get() == active_player_;
+  }
+
+  void switch_player() noexcept
+  {
+    active_player_ = (is_first_player() ? player2_.get() : player1_.get());
+  }
+
+  field::kind get_active_kind() const noexcept
+  {
+    return is_first_player() ? field::kind::black : field::kind::white;
+  }
+
+  bool is_game_finish() const noexcept
+  {
+    return true; // TODO: implement me;
+  }
+
+  std::unique_ptr<player> player1_;
+  std::unique_ptr<player> player2_;
+  player*                 active_player_;
+  field                   board_;
+};
+
+int main(int argc, char** argv)
+{
+  std::ios_base::sync_with_stdio(false);
+  game_master master {std::make_unique<computer_player>(), std::make_unique<computer_player>(), point{9, 9}};
+  master.run();
+}

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -64,19 +64,19 @@ public:
   }
 
   template<typename T>
-  data_type get_col(T x) const noexcept
+  const data_type get_col(T x) const noexcept
   {
     return data_[std::slice(get_access_number(x, 0), height(), width())];
   }
 
   template<typename T>
-  data_type get_row(T y) const noexcept
+  const data_type get_row(T y) const noexcept
   {
     return data_[std::slice(get_access_number(0, y), width(), 1)];
   }
 
   template<typename T>
-  data_type get_data(const T& specify) const
+  const data_type get_data(const T& specify) const
   {
     return data_[specify];
   }
@@ -238,19 +238,21 @@ private:
 
   bool is_game_finish() const noexcept
   {
-    const auto active_kind {get_active_kind()};
     const point::first_type horizon_limit {board_.width() - finish_length_ + 1};
     const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
+
     using search_data = std::tuple<point, point, std::size_t>;
     const std::array<const search_data, 4> search_datas {
       search_data{{0, horizon_limit}, {0, board_.height()}, 1}, // horizon
       search_data{{0, board_.width()}, {0, vertical_limit}, board_.width()}, // vertical
       search_data{{0, horizon_limit}, {0, vertical_limit}, board_.width() + 1}, // falling
       search_data{{finish_length_ - 1, board_.width()}, {0, vertical_limit}, board_.width() - 1}}; // soaring
+
+    const auto active_kind {get_active_kind()};
     for (const auto& e : search_datas)
       for (point::second_type y {std::get<1>(e).first}; y < std::get<1>(e).second; ++y)
         for (point::first_type x {std::get<0>(e).first}; x < std::get<0>(e).second; ++x) {
-          auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, std::get<2>(e)})};
+          const auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, std::get<2>(e)})};
           if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
         }
     const auto& all_area {board_.get_data()};
@@ -281,10 +283,10 @@ int main(int argc, char** argv)
   }
   std::size_t finish_size {5};
   if (argc > 2)
-    finish_size = std::stoul(argv[3]);
+    finish_size = std::stoul(argv[2]);
   std::size_t board_size {9};
   if (argc > 3)
-    board_size = std::stoul(argv[2]);
+    board_size = std::stoul(argv[3]);
 
   game_master master {std::move(player1), std::move(player2), point{board_size, board_size}, finish_size};
   master.run();


### PR DESCRIPTION
今の私が考えうる限りの全力を尽くして作りました。

使い方は、

```bash
command option finish_size board_size
```

`option`には `--auto`, `--player`, `--com` が選択できます。
`--auto`では両方NPC, `--player`では両方プレイヤー, `--com`ではコンピュータと対戦できます。
option以下を省略すると`--com`を選んだことになります。

`finish_size` はゲームクリアの設定変更です。　指定した数並べたら勝ちです。　1にするとplayer1が勝ちます。

`board_size` はボードのサイズを指定できます。　ただし、10以上の値を設定すると画面がずれます。

そんな感じです。

playerの挙動はポリモーフィズムで制御。
判定はstd::valarrayとstd::sliceを用いた範囲指示を利用。
game_masterはrunで一回遊べる仕様なので、
main内でrunを複数回実行すれば複数回遊べるようにすることもできます。

コンピュータのAIを追加するのもよし、複数回遊べるようにするのもよしな、拡張性に重きをおいた構成です。

ちなみに禁じ手の判定は何が禁じ手になるのか調べるのが面倒なのでしてません。
暇だったらするかも(やるフラグ)