### PR TITLE
Update gomoku optimize

### DIFF
--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -94,7 +94,7 @@ public:
     point head {diff_right_side < p.second ?
                 point{width() - 1, p.second - diff_right_side} :
                 point{p.first + p.second, 0}};
-    const std::size_t length {std::min(p.first + 1, height() - head.second)};
+    const std::size_t length {std::min(head.first + 1, height() - head.second)};
     return data_[std::slice(get_access_number(std::move(head)), length, width() - 1)];
   }
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -197,7 +197,7 @@ public:
 
   void draw(const field& value) const noexcept
   {
-    auto fp {[digit = std::log10(value.width()) + 1](const auto& e){std::cout << std::setw(digit) << e;}}; // format print
+    auto fp {[digit = std::log10(value.width() - 1) + 1](const auto& e){std::cout << std::setw(digit) << e;}}; // format print
     fp(' ');
     for (std::size_t i {}; i < value.width(); ++i)
       fp(i);

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -241,12 +241,9 @@ public:
   void run()
   {
     init();
-    while (true) { // when is_game_finish to break to end.
+    cout_renderer{}(board_, cout_renderer::turn{get_player_number()});
+    while (update()) {
       cout_renderer{}(board_, cout_renderer::turn{get_player_number()});
-      update();
-      if (is_game_finish())
-        break;
-      switch_player();
     }
     cout_renderer{}(board_, cout_renderer::winner{get_player_number()});
   }
@@ -259,10 +256,18 @@ private:
     board_.init();
   }
 
-  void update()
+  bool update()
   {
     current_put_ = active_player_->get_point(board_);
     board_.put(current_put_, get_active_kind());
+    if (is_invalid_put()) {
+      switch_player(); // winner is enemy.
+      return false; // game over.
+    }
+    if (is_game_finish())
+      return false; // game over.
+    switch_player();
+    return true; // continue.
   }
 
   bool is_first_player() const noexcept
@@ -307,6 +312,11 @@ private:
     const auto& all_area {board_.get_data()};
     if (std::none_of(std::begin(all_area), std::end(all_area), [](auto e){return e == field::kind::space;})) return true;
     return false;
+  }
+
+  bool is_invalid_put() const noexcept
+  {
+    return false; // TODO: implement me.
   }
 
   field                   board_;

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -231,13 +231,13 @@ public:
   {
     init();
     while (true) { // when is_game_finish to break to end.
-      draw();
+      cout_renderer{}(board_, cout_renderer::turn{is_first_player()});
       update();
       if (is_game_finish())
         break;
       switch_player();
     }
-    draw();
+    cout_renderer{}(board_);
     std::cout << "winner " << (is_first_player() ? "player 1" : "player 2") << std::endl;
   }
 
@@ -246,11 +246,6 @@ private:
   {
     active_player_ = player1_.get();
     board_.init();
-  }
-
-  void draw()
-  {
-    cout_renderer{}(board_, cout_renderer::turn{is_first_player()});
   }
 
   void update()

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -358,7 +358,7 @@ int main(int argc, char** argv)
   std::size_t finish_size {5};
   if (argc > 2)
     finish_size = std::stoul(argv[2]);
-  std::size_t board_size {9};
+  std::size_t board_size {15};
   if (argc > 3)
     board_size = std::stoul(argv[3]);
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -307,9 +307,6 @@ private:
 
   bool is_game_finish() const noexcept
   {
-    const point::first_type horizon_limit {board_.width() - finish_length_ + 1};
-    const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
-
     using search_data = std::tuple<point, point, std::size_t>;
     const std::array<const field::data_type, 4> search_datas {
       board_.get_row(current_put_.second), // horizon

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -219,11 +219,13 @@ class game_master
 public:
   template<typename Player1, typename Player2>
   game_master(std::unique_ptr<Player1> player1, std::unique_ptr<Player2> player2, point size, std::size_t finish_length = 5)
-    : player1_       {player1.release()},
+    : board_         {std::move(size)},
+      finish_length_ {board_.is_valid(finish_length - 1, finish_length - 1) ? 
+                      finish_length :
+                      throw std::out_of_range{"game_master: cannot clear with finish_length > board_size"}},
+      player1_       {player1.release()},
       player2_       {player2.release()},
-      active_player_ {player1_.get()},
-      board_         {std::move(size)},
-      finish_length_ {board_.is_valid(finish_length - 1, finish_length - 1) ? finish_length : throw std::out_of_range{"game_master: cannot clear/ finish_length > board_size"}}
+      active_player_ {player1_.get()}
   {
   }
 
@@ -297,11 +299,11 @@ private:
     return false;
   }
 
+  field                   board_;
+  std::size_t             finish_length_;
   std::unique_ptr<player> player1_;
   std::unique_ptr<player> player2_;
   player*                 active_player_;
-  field                   board_;
-  std::size_t             finish_length_;
 };
 
 int main(int argc, char** argv)
@@ -321,7 +323,7 @@ int main(int argc, char** argv)
   std::size_t finish_size {5};
   if (argc > 2)
     finish_size = std::stoul(argv[2]);
-  std::size_t board_size {9};
+  std::size_t board_size {10};
   if (argc > 3)
     board_size = std::stoul(argv[3]);
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -271,10 +271,10 @@ public:
   void run(Renderer rend)
   {
     init();
-    rend("The start of game.", board_, cout_renderer::turn{get_player_number()});
-    while (update()) {
+    rend("The start of game.");
+    do {
       rend(board_, cout_renderer::turn{get_player_number()});
-    }
+    } while (update());
     rend(board_, "Game clear.", cout_renderer::winner{get_player_number()});
   }
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -218,12 +218,12 @@ public:
     fp(' ');
     for (std::size_t i {}; i < value.width(); ++i)
       fp(i + 1);
-    std::cout << '\n';
+    std::cout.put('\n');
     for (std::size_t y {}; y < value.height(); ++y) {
       fp(y + 1);
       auto line {value.get_row(y)};
       std::for_each(std::begin(line), std::end(line), [fp](auto e){fp(to_string(e));});
-      std::cout << '\n';
+      std::cout.put('\n');
     }
   }
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -73,19 +73,19 @@ public:
   }
 
   template<typename T>
-  const data_type get_col(T x) const noexcept
+  data_type get_col(T x) const noexcept
   {
     return data_[std::slice(get_access_number(x, 0), height(), width())];
   }
 
   template<typename T>
-  const data_type get_row(T y) const noexcept
+  data_type get_row(T y) const noexcept
   {
     return data_[std::slice(get_access_number(0, y), width(), 1)];
   }
 
   template<typename T>
-  const data_type get_data(const T& specify) const
+  data_type get_data(const T& specify) const
   {
     return data_[specify];
   }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -12,6 +12,7 @@
 
 //! The point class. But I don't implement it.
 using point = std::pair<std::size_t, std::size_t>;
+constexpr point invalid_point {-1, -1};
 
 //! The game field class.
 class field
@@ -247,12 +248,14 @@ private:
   void init()
   {
     active_player_ = player1_.get();
+    current_put_ = invalid_point;
     board_.init();
   }
 
   void update()
   {
-    board_.put(active_player_->get_point(board_), get_active_kind());
+    current_put_ = active_player_->get_point(board_);
+    board_.put(current_put_, get_active_kind());
   }
 
   bool is_first_player() const noexcept
@@ -301,6 +304,7 @@ private:
 
   field                   board_;
   std::size_t             finish_length_;
+  point                   current_put_ {invalid_point};
   std::unique_ptr<player> player1_;
   std::unique_ptr<player> player2_;
   player*                 active_player_;

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -84,14 +84,19 @@ public:
 
   data_type get_falling(const point p) const noexcept
   {
-    const point head {p.first < p.second ? point{0, p.second - p.first} : point{p.first - p.second, 0}};
+    point head {p.first < p.second ? point{0, p.second - p.first} : point{p.first - p.second, 0}};
     const std::size_t length {std::min(width() - head.first, height() - head.second)};
     return data_[std::slice(get_access_number(std::move(head)), length, width() + 1)];
   }
 
-  data_type get_soaring(point p) const noexcept
+  data_type get_soaring(const point p) const noexcept
   {
-    return data_type{}; // TODO: implement me.
+    const point::first_type diff_right_side {width() - 1 - p.first};
+    point head {diff_right_side < p.second ?
+                point{width() - 1, p.second - diff_right_side} :
+                point{p.first + p.second, 0}};
+    const std::size_t length {std::min(p.first + 1, height() - head.second)};
+    return data_[std::slice(get_access_number(std::move(head)), length, width() - 1)];
   }
 
   template<typename T>

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -180,8 +180,8 @@ private:
 class cout_renderer
 {
 public:
-  struct turn {bool b;};
-  struct winner {bool b;};
+  struct turn {std::size_t player_number; std::size_t turn_number;};
+  struct winner {std::size_t player_number;};
 
   void operator()() const noexcept
   {
@@ -212,12 +212,12 @@ public:
 
   void draw(turn t) const noexcept
   {
-    std::cout << "\nThe turn of player " << (t.b ? 1 : 2) << ".\n";
+    std::cout << "\nThe turn of player " << t.player_number << ".\n";
   }
 
   void draw(winner w) const noexcept
   {
-    std::cout << "winner player " << (w.b ? 1 : 2) << ".\n";
+    std::cout << "winner player " << w.player_number << ".\n";
   }
 };
 
@@ -240,13 +240,13 @@ public:
   {
     init();
     while (true) { // when is_game_finish to break to end.
-      cout_renderer{}(board_, cout_renderer::turn{is_first_player()});
+      cout_renderer{}(board_, cout_renderer::turn{get_player_number()});
       update();
       if (is_game_finish())
         break;
       switch_player();
     }
-    cout_renderer{}(board_, cout_renderer::winner{is_first_player()});
+    cout_renderer{}(board_, cout_renderer::winner{get_player_number()});
   }
 
 private:

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -146,6 +146,8 @@ public:
         continue;
       }
       std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+      --p.first;
+      --p.second;
       if (valid_area.is_valid(p))
         return p;
       std::cout << "wrong input..\n"; // out range or exist value.
@@ -197,13 +199,13 @@ public:
 
   void draw(const field& value) const noexcept
   {
-    auto fp {[digit = std::log10(value.width() - 1) + 1](const auto& e){std::cout << std::setw(digit) << e;}}; // format print
+    auto fp {[digit = std::log10(value.width()) + 1](const auto& e){std::cout << std::setw(digit) << e;}}; // format print
     fp(' ');
     for (std::size_t i {}; i < value.width(); ++i)
-      fp(i);
+      fp(i + 1);
     std::cout << '\n';
     for (std::size_t y {}; y < value.height(); ++y) {
-      fp(y);
+      fp(y + 1);
       auto line {value.get_row(y)};
       std::for_each(std::begin(line), std::end(line), [fp](auto e){fp(to_string(e));});
       std::cout << '\n';
@@ -332,7 +334,7 @@ int main(int argc, char** argv)
   std::size_t finish_size {5};
   if (argc > 2)
     finish_size = std::stoul(argv[2]);
-  std::size_t board_size {10};
+  std::size_t board_size {9};
   if (argc > 3)
     board_size = std::stoul(argv[3]);
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -252,14 +252,15 @@ public:
   {
   }
 
-  void run()
+  template<typename Renderer>
+  void run(Renderer rend)
   {
     init();
-    cout_renderer{}(board_, cout_renderer::turn{get_player_number()});
+    rend(board_, cout_renderer::turn{get_player_number()});
     while (update()) {
-      cout_renderer{}(board_, cout_renderer::turn{get_player_number()});
+      rend(board_, cout_renderer::turn{get_player_number()});
     }
-    cout_renderer{}(board_, cout_renderer::winner{get_player_number()});
+    rend(board_, cout_renderer::winner{get_player_number()});
   }
 
 private:
@@ -361,5 +362,5 @@ int main(int argc, char** argv)
     board_size = std::stoul(argv[3]);
 
   game_master master {std::move(player1), std::move(player2), point{board_size, board_size}, finish_size};
-  master.run();
+  master.run(cout_renderer{});
 }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -214,14 +214,14 @@ public:
 
   void draw(const field& value) const noexcept
   {
-    auto fp {[digit = std::log10(value.width()) + 1](const auto& e){std::cout << std::setw(digit) << e;}}; // format print
+    auto fp {[digit = std::log10(value.width()) + 1](auto e){std::cout << std::setw(digit) << e;}}; // format print
     fp(' ');
     for (std::size_t i {}; i < value.width(); ++i)
       fp(i + 1);
     std::cout.put('\n');
     for (std::size_t y {}; y < value.height(); ++y) {
       fp(y + 1);
-      auto line {value.get_row(y)};
+      field::data_type line {value.get_row(y)};
       std::for_each(std::begin(line), std::end(line), [fp](auto e){fp(to_string(e));});
       std::cout.put('\n');
     }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -57,8 +57,7 @@ public:
     return size_.second;
   }
 
-  template<typename T1, typename T2>
-  std::size_t get_access_number(T1 x, T2 y) const noexcept
+  std::size_t get_access_number(point::first_type x, point::second_type y) const noexcept
   {
     return width() * y + x;
   }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -150,7 +150,7 @@ public:
       --p.second;
       if (valid_area.is_valid(p))
         return p;
-      std::cout << "wrong input..\n"; // out range or exist value.
+      std::cout << "wrong input.\n"; // out range or exist value.
     }
   }
 };

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -38,7 +38,7 @@ public:
   void put(point p, kind k)
   {
     if (!is_valid(p)) throw std::out_of_range {"field: fail access on put the stone"};
-    access(std::move(p)) = k;
+    access(std::move(p)) = std::move(k);
   }
 
   bool is_valid(point p) const noexcept
@@ -49,7 +49,7 @@ public:
 
   bool is_valid(point::first_type x, point::second_type y) const noexcept
   {
-    return is_valid({x, y});
+    return is_valid({std::move(x), std::move(y)});
   }
 
   point::first_type width() const noexcept
@@ -62,7 +62,7 @@ public:
     return size_.second;
   }
 
-  std::size_t get_access_number(point::first_type x, point::second_type y) const noexcept
+  std::size_t get_access_number(const point::first_type x, const point::second_type y) const noexcept
   {
     return width() * y + x;
   }
@@ -74,12 +74,12 @@ public:
 
   data_type get_col(point::first_type x) const noexcept
   {
-    return data_[std::slice(get_access_number(x, 0), height(), width())];
+    return data_[std::slice(get_access_number(std::move(x), 0), height(), width())];
   }
 
   data_type get_row(point::second_type y) const noexcept
   {
-    return data_[std::slice(get_access_number(0, y), width(), 1)];
+    return data_[std::slice(get_access_number(0, std::move(y)), width(), 1)];
   }
 
   template<typename T>
@@ -113,7 +113,7 @@ private:
   data_type data_;
 };
 
-char to_string(field::kind k) noexcept
+char to_string(const field::kind k) noexcept
 {
   return k == field::kind::space ? ' ' :
          k == field::kind::white ? 'O' :
@@ -210,12 +210,12 @@ public:
     }
   }
 
-  void draw(turn t) const noexcept
+  void draw(const turn t) const noexcept
   {
     std::cout << "\nThe turn of player " << t.player_number << ".\n";
   }
 
-  void draw(winner w) const noexcept
+  void draw(const winner w) const noexcept
   {
     std::cout << "winner player " << w.player_number << ".\n";
   }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -214,10 +214,12 @@ public:
   void draw(const field& value) const noexcept
   {
     auto fp {[digit = std::log10(value.width()) + 1](auto e){std::cout << std::setw(digit) << e;}}; // format print
+    // header print
     fp(' ');
     for (std::size_t i {}; i < value.width(); ++i)
       fp(i + 1);
     std::cout.put('\n');
+    // board print
     for (std::size_t y {}; y < value.height(); ++y) {
       fp(y + 1);
       field::data_type line {value.get_row(y)};
@@ -234,6 +236,19 @@ public:
   void draw(const winner w) const noexcept
   {
     std::cout << "winner player " << w.player_number << ".\n";
+  }
+
+  template<std::size_t N>
+  void draw(const char (&s)[N]) const noexcept
+  {
+    std::cout.write(s, N);
+    std::cout.put('\n');
+  }
+
+  template<typename traits, typename Allocator>
+  void draw(const std::basic_string<char, traits, Allocator>& s) const noexcept
+  {
+    std::cout << s << '\n';
   }
 };
 
@@ -256,11 +271,11 @@ public:
   void run(Renderer rend)
   {
     init();
-    rend(board_, cout_renderer::turn{get_player_number()});
+    rend("The start of game.", board_, cout_renderer::turn{get_player_number()});
     while (update()) {
       rend(board_, cout_renderer::turn{get_player_number()});
     }
-    rend(board_, cout_renderer::winner{get_player_number()});
+    rend(board_, "Game clear.", cout_renderer::winner{get_player_number()});
   }
 
 private:

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -6,7 +6,6 @@
 #include <memory>
 #include <numeric>
 #include <stdexcept>
-#include <tuple>
 #include <utility>
 #include <valarray>
 
@@ -307,7 +306,6 @@ private:
 
   bool is_game_finish() const noexcept
   {
-    using search_data = std::tuple<point, point, std::size_t>;
     const std::array<const field::data_type, 4> search_datas {
       board_.get_row(current_put_.second), // horizon
       board_.get_col(current_put_.first), // vertical

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -1,8 +1,10 @@
+#include <array>
 #include <cstddef>
 #include <iostream>
 #include <memory>
 #include <numeric>
 #include <stdexcept>
+#include <tuple>
 #include <utility>
 #include <valarray>
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -82,10 +82,11 @@ public:
     return data_[std::slice(get_access_number(std::move(x), 0), height(), width())];
   }
 
-  data_type get_falling(point p) const noexcept
+  data_type get_falling(const point p) const noexcept
   {
-    const point first {p.first < p.second ? point{0, p.second - p.first} : point{p.second - p.first, 0}};
-    return data_type{}; // TODO: implement me.
+    const point head {p.first < p.second ? point{0, p.second - p.first} : point{p.first - p.second, 0}};
+    const std::size_t length {std::min(width() - head.first, height() - head.second)};
+    return data_[std::slice(get_access_number(std::move(head)), length, width() + 1)];
   }
 
   data_type get_soaring(point p) const noexcept

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -72,14 +72,25 @@ public:
     return get_access_number(p.first, p.second);
   }
 
+  data_type get_row(point::second_type y) const noexcept
+  {
+    return data_[std::slice(get_access_number(0, std::move(y)), width(), 1)];
+  }
+
   data_type get_col(point::first_type x) const noexcept
   {
     return data_[std::slice(get_access_number(std::move(x), 0), height(), width())];
   }
 
-  data_type get_row(point::second_type y) const noexcept
+  data_type get_falling(point p) const noexcept
   {
-    return data_[std::slice(get_access_number(0, std::move(y)), width(), 1)];
+    const point first {p.first < p.second ? point{0, p.second - p.first} : point{p.second - p.first, 0}};
+    return data_type{}; // TODO: implement me.
+  }
+
+  data_type get_soaring(point p) const noexcept
+  {
+    return data_type{}; // TODO: implement me.
   }
 
   template<typename T>
@@ -294,21 +305,21 @@ private:
     const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
 
     using search_data = std::tuple<point, point, std::size_t>;
-    const std::array<const search_data, 4> search_datas {
-      search_data{{0, horizon_limit}, {0, board_.height()}, 1}, // horizon
-      search_data{{0, board_.width()}, {0, vertical_limit}, board_.width()}, // vertical
-      search_data{{0, horizon_limit}, {0, vertical_limit}, board_.width() + 1}, // falling
-      search_data{{finish_length_ - 1, board_.width()}, {0, vertical_limit}, board_.width() - 1}}; // soaring
+    std::array<field::data_type, 4> search_datas {
+      board_.get_row(current_put_.first), // horizon
+      board_.get_col(current_put_.second), // vertical
+      board_.get_falling(current_put_), // falling
+      board_.get_soaring(current_put_)}; // soaring
 
-    const auto active_kind {get_active_kind()};
-    for (const auto& e : search_datas)
-      for (point::second_type y {std::get<1>(e).first}; y < std::get<1>(e).second; ++y)
-        for (point::first_type x {std::get<0>(e).first}; x < std::get<0>(e).second; ++x) {
-          const auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, std::get<2>(e)})};
-          if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
-        }
-    const auto& all_area {board_.get_data()};
-    if (std::none_of(std::begin(all_area), std::end(all_area), [](auto e){return e == field::kind::space;})) return true;
+//    const auto active_kind {get_active_kind()};
+//    for (const auto& e : search_datas)
+//      for (point::second_type y {std::get<1>(e).first}; y < std::get<1>(e).second; ++y)
+//        for (point::first_type x {std::get<0>(e).first}; x < std::get<0>(e).second; ++x) {
+//          const auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, std::get<2>(e)})};
+//          if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
+//        }
+//    const auto& all_area {board_.get_data()};
+//    if (std::none_of(std::begin(all_area), std::end(all_area), [](auto e){return e == field::kind::space;})) return true;
     return false;
   }
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -311,21 +311,23 @@ private:
     const point::second_type vertical_limit {board_.height() - finish_length_ + 1};
 
     using search_data = std::tuple<point, point, std::size_t>;
-    std::array<field::data_type, 4> search_datas {
-      board_.get_row(current_put_.first), // horizon
-      board_.get_col(current_put_.second), // vertical
+    const std::array<const field::data_type, 4> search_datas {
+      board_.get_row(current_put_.second), // horizon
+      board_.get_col(current_put_.first), // vertical
       board_.get_falling(current_put_), // falling
       board_.get_soaring(current_put_)}; // soaring
 
-//    const auto active_kind {get_active_kind()};
-//    for (const auto& e : search_datas)
-//      for (point::second_type y {std::get<1>(e).first}; y < std::get<1>(e).second; ++y)
-//        for (point::first_type x {std::get<0>(e).first}; x < std::get<0>(e).second; ++x) {
-//          const auto line {board_.get_data(std::slice{board_.get_access_number(x, y), finish_length_, std::get<2>(e)})};
-//          if (std::all_of(std::begin(line), std::end(line), [active_kind](auto e){return e == active_kind;})) return true;
-//        }
-//    const auto& all_area {board_.get_data()};
-//    if (std::none_of(std::begin(all_area), std::end(all_area), [](auto e){return e == field::kind::space;})) return true;
+    for (const auto& e : search_datas) {
+      if (e.size() < finish_length_) continue; // too short.
+      for (std::size_t i {0}; i < e.size() - finish_length_ + 1; ++i) {
+        field::data_type line {e[std::slice(i, finish_length_, 1)]};
+        if (std::all_of(std::begin(line), std::end(line), [active_kind = get_active_kind()](auto e){return e == active_kind;}))
+          return true;
+      }
+    }
+
+    const auto& all_area {board_.get_data()};
+    if (std::none_of(std::begin(all_area), std::end(all_area), [](auto e){return e == field::kind::space;})) return true;
     return false;
   }
 

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -72,14 +72,12 @@ public:
     return get_access_number(p.first, p.second);
   }
 
-  template<typename T>
-  data_type get_col(T x) const noexcept
+  data_type get_col(point::first_type x) const noexcept
   {
     return data_[std::slice(get_access_number(x, 0), height(), width())];
   }
 
-  template<typename T>
-  data_type get_row(T y) const noexcept
+  data_type get_row(point::second_type y) const noexcept
   {
     return data_[std::slice(get_access_number(0, y), width(), 1)];
   }

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -136,10 +136,16 @@ public:
       std::cout << "where set to? [x y]\n > " << std::flush;
       point p;
       std::cin >> p.first >> p.second;
+      if (std::cin.fail()) {
+        std::cin.clear();
+        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        std::cout << "please input double numbers.\n"; // wrong input.
+        continue;
+      }
       std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
       if (valid_area.is_valid(p))
         return p;
-      std::cout << "wrong input.\n"; // out range
+      std::cout << "wrong input..\n"; // out range or exist value.
     }
   }
 };

--- a/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
+++ b/cpp_edision/gomoku_game/gomoku_game_optimize.cpp
@@ -181,6 +181,7 @@ class cout_renderer
 {
 public:
   struct turn {bool b;};
+  struct winner {bool b;};
 
   void operator()() const noexcept
   {
@@ -213,6 +214,11 @@ public:
   {
     std::cout << "\nThe turn of player " << (t.b ? 1 : 2) << ".\n";
   }
+
+  void draw(winner w) const noexcept
+  {
+    std::cout << "winner player " << (w.b ? 1 : 2) << ".\n";
+  }
 };
 
 class game_master
@@ -240,8 +246,7 @@ public:
         break;
       switch_player();
     }
-    cout_renderer{}(board_);
-    std::cout << "winner " << (is_first_player() ? "player 1" : "player 2") << std::endl;
+    cout_renderer{}(board_, cout_renderer::winner{is_first_player()});
   }
 
 private:


### PR DESCRIPTION
描画がずれないように描画用のクラスを追加。
終了判定を大幅に改良。計算量が約 (1/board_.size()) に減りました。

あと入力に誤って数字以外を入れた時に正常に復帰するようにしたり、
盤面は0からではなく1からの表示にしたりしました。

連珠という五目並べ公式みたいなやつがあるので、
それに合わせてボードサイズを15*15にしました。

あとはis_invalid_put関数に禁じ手の判定を実装すれば完成です。
禁じ手ェ…。